### PR TITLE
New Feature: Debug Console

### DIFF
--- a/src/logging.janet
+++ b/src/logging.janet
@@ -1,3 +1,5 @@
+(import spork/rpc)
+
 (defn init-logger []
   (setdyn :out stderr)
   (spit "janetlsp.log.txt" ""))
@@ -6,6 +8,24 @@
   (file/close (dyn :logfile)))
 
 (defn log [output]
+  
+  (pp (dyn :console))
+  
+  (when true
+    (print "Trying to ping console")
+    (unless (dyn :client)
+      (def opts (dyn :opts))
+
+      (print "Trying to create a client")
+      
+      (def host "127.0.0.1")
+      (def port (if (opts :port) (string (opts :port)) "8037"))
+
+      (setdyn :client (rpc/client host port))
+      (pp (dyn :client)))
+
+    (print (:print (dyn :client) output)))
+  
   (when (dyn :debug)
     (spit "janetlsp.log.txt" (string output "\n") :a)
     (file/write stderr (string output "\n"))))

--- a/src/logging.janet
+++ b/src/logging.janet
@@ -8,24 +8,24 @@
   (file/close (dyn :logfile)))
 
 (defn log [output]
-  
-  (pp (dyn :console))
-  
-  (when true
-    (print "Trying to ping console")
-    (unless (dyn :client)
-      (def opts (dyn :opts))
 
-      (print "Trying to create a client")
-      
-      (def host "127.0.0.1")
-      (def port (if (opts :port) (string (opts :port)) "8037"))
+  (comment pp (dyn :console))
 
-      (setdyn :client (rpc/client host port))
-      (pp (dyn :client)))
+  (comment print "Trying to ping console")
+  (unless (dyn :client)
+    (def opts (dyn :opts))
 
+    (comment print "Trying to create a client")
+
+    (def host "127.0.0.1")
+    (def port (if (opts :port) (string (opts :port)) "8037"))
+
+    (setdyn :client (try (rpc/client host port) ([_] "No debug console detected")))
+    (comment pp (dyn :client)))
+
+  (when (not= (dyn :client) "No debug console detected")
     (print (:print (dyn :client) output)))
-  
+
   (when (dyn :debug)
     (spit "janetlsp.log.txt" (string output "\n") :a)
     (file/write stderr (string output "\n"))))

--- a/src/main.janet
+++ b/src/main.janet
@@ -276,7 +276,7 @@
   (let [message (read-message)]
     (match (handle-message message state)
       [:ok new-state response] (do
-                                 (logging/log (string/format "successful rpc: \n - New state: %m \n - Response: %m" new-state response))
+                                 (logging/log "successful rpc")
                                  (write-response stdout (rpc/success-response (get message "id") response))
                                  (message-loop :state new-state))
       [:noresponse new-state] (message-loop :state new-state)


### PR DESCRIPTION
- Console
  - Running `janet-lsp --console` now starts a listener that will auto-accept connections from new `janet-lsp` instances launched on the same machine.
  - Debug print messages and reports from the connected `janet-lsp` instance(s?) will display in the debug console.
  - Related: #12 .
- Misc
  - Refactor CLI argument parsing to use `ianthehenry/cmd` rather than `spork/argparse`.