### PR TITLE
Improvement: Multiple Diagnostic Errors

### DIFF
--- a/src/eval.janet
+++ b/src/eval.janet
@@ -63,20 +63,22 @@
 
   (def eval-fiber
     (fiber/new
-     |(do (var returnval :ok)
+     |(do (var returnval @[])
           (try (run-context {:chunks chunks
                              :on-compile-error (fn compile-error [msg errf where line col]
-                                                 (set returnval [:error {:message msg
-                                                                         :location [line col]}]))
+                                                 (array/push returnval {:message msg
+                                                                        :location [line col]}))
                              :on-parse-error (fn parse-error [p x]
-                                               (set returnval [:error {:message (parser/error p)
-                                                                       :location (parser/where p)}]))
+                                               (array/push returnval {:message (parser/error p)
+                                                                      :location (parser/where p)}))
                              :evaluator flycheck-evaluator
                              :fiber-flags :i
                              :source filename})
                ([err]
-                (set returnval [:error {:message err
-                                        :location [0 0]}])))
+                # (logging/log (string/format "%m" [:error {:message err
+                #                                           :location [0 0]}]))
+                (array/push returnval {:message err
+                                       :location [0 0]})))
           # (logging/log (string/format "from within fiber, returnval is: %m" returnval))
           returnval) :e (dyn :eval-env)))
   (def eval-fiber-return (resume eval-fiber))

--- a/src/eval.janet
+++ b/src/eval.janet
@@ -75,15 +75,10 @@
                              :fiber-flags :i
                              :source filename})
                ([err]
-                # (logging/log (string/format "%m" [:error {:message err
-                #                                           :location [0 0]}]))
                 (array/push returnval {:message err
                                        :location [0 0]})))
-          # (logging/log (string/format "from within fiber, returnval is: %m" returnval))
           returnval) :e (dyn :eval-env)))
   (def eval-fiber-return (resume eval-fiber))
-  # (logging/log (string/format "eval-fiber-return is: %m" eval-fiber-return))
-  # (logging/log (string/format "fiber last value was: %m" (fiber/last-value eval-fiber))) 
   eval-fiber-return)
 
 # tests

--- a/src/main.janet
+++ b/src/main.janet
@@ -45,16 +45,17 @@
 (defn on-document-diagnostic [state params] 
   (let [uri (get-in params ["textDocument" "uri"])
         content (get-in state [:documents uri :content])
-        items @[]]
-
-    (match (eval/eval-buffer content (path/basename uri))
-      :ok ()
-      [:error {:location [line col] :message message}]
-      (array/push items
-                  {:range
-                   {:start {:line (max 0 (dec line)) :character col}
-                    :end   {:line (max 0 (dec line)) :character col}}
-                   :message message}))
+        items @[]
+        eval-result (eval/eval-buffer content (path/basename uri))]
+ 
+    (each res eval-result
+      (match res
+        {:location [line col] :message message}
+        (array/push items
+                    {:range
+                     {:start {:line (max 0 (dec line)) :character col}
+                      :end   {:line (max 0 (dec line)) :character col}}
+                     :message message}))) 
 
     [:ok state {:kind "full"
                 :items items}]))


### PR DESCRIPTION
- Diagnostics
  - `textDocument/diagnostic` now returns ALL compiler errors encountered in the active document, not just the latter-most one