### PR TITLE
Bug fixes and code cleanliness improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,36 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+Format for entires is <version-string> - release date.
 
-  # Changelog
-  All notable changes to this project will be documented in this file.
-  Format for entires is <version-string> - release date.
+## 0.0.3 - 2024-01-09
 
-  ## 0.0.1 - 2023-09-26
-  - Hard forked this project from [JohnDoneth/janet-language-server](https://github.com/JohnDoneth/janet-language-server).
+- Completion
+  - Add basic CompletionItemKind by @fnurk in https://github.com/CFiggers/janet-lsp/pull/9
+- Formatting
+  - New feature: Document formatting by @CFiggers in https://github.com/CFiggers/janet-lsp/pull/13
+- Signature Helps
+  - New Feature: Signature Helps by @CFiggers in https://github.com/CFiggers/janet-lsp/pull/14
+- Debug Console
+  - New Feature: Debug Console by @CFiggers in https://github.com/CFiggers/janet-lsp/pull/15
+- Diagnostics
+  - Improvement: Multiple Diagnostic Errors by @CFiggers in https://github.com/CFiggers/janet-lsp/pull/16
+- Cross-cutting
+  - Separate environment for flychecking user code (better separation between running server env and diagnostic eval env)
+  - Replace `spork/argparse` with `ianthehenry/cmd` for command line argument parsing
+  - Bug fixes
+
+## 0.0.2 - 2023-10-24
+
+- Hover
+  - Improved hover documentation (more detailed info, syntax highlighting for function signatures)
+- Completion
+  - Added `project.janet` symbols for jpm (`declare-project`, `declare-native`, `declare-executable`, etc.)
+- General
+  - Improved module loading logic for eval/completion environment
+  - Replaced `spork/json` dependency with `CFiggers/jayson` for .jimage compatibility
+  - Handle `shutdown` and `exit` lifecycle requests properly
+
+## 0.0.1 - 2023-09-26
+
+- Hard forked this project from [JohnDoneth/janet-language-server](https://github.com/JohnDoneth/janet-language-server).
   

--- a/src/eval.janet
+++ b/src/eval.janet
@@ -86,57 +86,57 @@
 
 (deftest "test eval-buffer: (+ 2 2)"
   (setdyn :eval-env (make-env root-env))
-  (test (eval-buffer "(+ 2 2)") :ok))
+  (test (eval-buffer "(+ 2 2)") @[]))
 
 (deftest "test eval-buffer: (2)"
   (setdyn :eval-env (make-env root-env))
   (test (eval-buffer "(2)")
-    [:error
-     {:location [1 1]
-      :message "2 expects 1 argument, got 0"}]))
+    @[{:location [1 1]
+       :message "2 expects 1 argument, got 0"}]))
 
 (deftest "test eval-buffer: (+ 2 2"
   (setdyn :eval-env (make-env root-env))
   (test (eval-buffer "(+ 2 2")
-    [:error
-     {:location [2 0]
-      :message "unexpected end of source, ( opened at line 1, column 1"}]))
+    @[{:location [2 0]
+       :message "unexpected end of source, ( opened at line 1, column 1"}]))
 
 # check for side effects
 (deftest "test eval-buffer: (pp 42)"
   (setdyn :eval-env (make-env root-env))
-  (test (eval-buffer "(pp 42)") :ok))
+  (test (eval-buffer "(pp 42)") @[]))
 
 (deftest "test eval-buffer: ()"
   (setdyn :eval-env (make-env root-env))
   (test (eval-buffer "()")
-    [:error
-     {:location [0 0]
-      :message "expected integer key for tuple in range [0, 0), got 0"}]))
+    @[{:location [0 0]
+       :message "expected integer key for tuple in range [0, 0), got 0"}]))
 
 (deftest "import with no argument should give a parse error"
   (setdyn :eval-env (make-env root-env))
   (test (eval-buffer "(import )")
-    [:error
-     {:location [1 1]
-      :message "macro arity mismatch, expected at least 1, got 0"}]))
+    @[{:location [1 1]
+       :message "macro arity mismatch, expected at least 1, got 0"}]))
 
 (deftest "import with no matching module should give a parse error"
   (setdyn :eval-env (make-env root-env))
   (test (eval-buffer "(import randommodulethatdoesntexist)")
-    [:error
-     {:location [0 0]
-      :message "could not find module randommodulethatdoesntexist:\n    /usr/local/lib/janet/randommodulethatdoesntexist.jimage\n    /usr/local/lib/janet/randommodulethatdoesntexist.janet\n    /usr/local/lib/janet/randommodulethatdoesntexist/init.janet\n    /usr/local/lib/janet/randommodulethatdoesntexist.so"}]))
+    @[{:location [0 0]
+       :message "could not find module randommodulethatdoesntexist:\n    /usr/local/lib/janet/randommodulethatdoesntexist.jimage\n    /usr/local/lib/janet/randommodulethatdoesntexist.janet\n    /usr/local/lib/janet/randommodulethatdoesntexist/init.janet\n    /usr/local/lib/janet/randommodulethatdoesntexist.so"}]))
 
 (deftest "does not error because string/trim is a cfunction"
   (setdyn :eval-env (make-env root-env))
-  (test (eval-buffer "(string/trim )") :ok))
+  (test (eval-buffer "(string/trim )") @[]))
 
 (deftest "should give a parser error 2"
   (setdyn :eval-env (make-env root-env))
   (test (eval-buffer "(freeze )")
-    [:error
-     {:location [1 1]
-      :message "<function freeze> expects at least 1 argument, got 0"}]))
+    @[{:location [1 1]
+       :message "<function freeze> expects at least 1 argument, got 0"}]))
 
-
+(deftest "multiple compiler errors"
+  (setdyn :eval-env (make-env root-env))
+  (test (eval-buffer "(freeze ) (import )")
+    @[{:location [1 1]
+       :message "<function freeze> expects at least 1 argument, got 0"}
+      {:location [1 11]
+       :message "macro arity mismatch, expected at least 1, got 0"}]))

--- a/src/eval.janet
+++ b/src/eval.janet
@@ -52,7 +52,8 @@
             ((compile newtup env where)))
           (thunk))))))
 
-(defn eval-buffer [str filename]
+(defn eval-buffer [str &opt filename]
+  (default filename "eval.janet")
   (var state (string str))
   (defn chunks [buf parser]
     (def ret state)

--- a/src/logging.janet
+++ b/src/logging.janet
@@ -1,12 +1,5 @@
 (import spork/rpc)
 
-(defn init-logger []
-  (setdyn :out stderr)
-  (spit "janetlsp.log.txt" ""))
-
-(defn shutdown-logger []
-  (file/close (dyn :logfile)))
-
 (defn log [output]
 
   (comment pp (dyn :console))

--- a/src/lookup.janet
+++ b/src/lookup.janet
@@ -29,16 +29,32 @@
               (break)))
        ret)))
 
+(test (peg/match word-peg "(defn main [& args] (+ 1 1))")
+  @[[0 "" 0]
+    [1 "defn" 5]
+    [6 "main" 10]
+    [11 "[&" 13]
+    [14 "args]" 19]
+    [20 "" 20]
+    [21 "+" 22]
+    [23 "1" 24]
+    [25 "1" 26]
+    [27 "" 27]])
+
+(test (peg/match word-peg "") nil)
+
 (defn word-at [location source]
   # (logging/log (string/format "word-at received location: %m" location))
   # (logging/log (string/format "word-at received source: %m" source))
   (let [{:character character-pos :line line-pos} location
         line ((string/split "\n" source) line-pos)
-        parsed (sort-by last (peg/match word-peg line))
+        parsed (or (sort-by last (or (peg/match word-peg line) @[[0 "" 0]])))
         word (or (first-where |(>= ($ 2) character-pos) parsed) (last parsed))]
     {:range [(word 0) (word 2)] :word (word 1)}))
 
 (test (word-at {:line 0 :character 16} "(def- parse-peg\n") {:range [6 14] :word "parse-peg"})
+
+(test (word-at {:line 1 :character 0} "(import )\n") {:range [0 0] :word ""})
 
 (def sexp-peg
   (peg/compile

--- a/src/main.janet
+++ b/src/main.janet
@@ -292,9 +292,7 @@
 
   (message-loop :state @{:documents @{}}))
 
-(defn start-debug-console []
-  (setdyn :debug true)
-
+(defn start-debug-console [] 
   (def host "127.0.0.1")
   (def port (if ((dyn :opts) :port) (string ((dyn :opts) :port)) "8037"))
   
@@ -324,6 +322,7 @@
      "A Language Server (LSP) for the Janet Programming Language."
      [[--dont-search-jpm-tree -j] (flag) "Whether to search `jpm_tree` for modules."
       --stdio (flag) "Use STDIO."
+      [--debug -d] (flag) "Print debug messages."
       [--console -c] (flag) "Start a debug console instead of starting the Language Server."
       [--debug-port -p] (optional :int++) "What port to start the debug console on. Defaults to 8037."]
 
@@ -337,6 +336,7 @@
         :debug-port debug-port})
 
      (setdyn :opts opts)
+     (setdyn :debug debug)
      (setdyn :out stderr)
 
      (if console

--- a/src/misc.janet
+++ b/src/misc.janet
@@ -1,3 +1,5 @@
+(use judge)
+
 (defmacro letv [bindings & body]
   ~(do ,;(seq [[k v] :in (partition 2 bindings)] ['var k v]) ,;body))
 

--- a/test/basic.janet
+++ b/test/basic.janet
@@ -1,6 +1,0 @@
-(use ../src/main)
-
-(use judge)
-
-(deftest "placeholder" 
-  (test (= :Hello! "Hello!") false))

--- a/test/test-main.janet
+++ b/test/test-main.janet
@@ -1,0 +1,91 @@
+(use judge)
+
+(use ../src/main)
+
+(deftest "parse-content-length"
+  (test (parse-content-length "000:123:456:789") 123)
+  (test (parse-content-length "123:456:789") 456)
+  (test (parse-content-length "0123:456::::789") 456))
+
+(deftest "test binding-to-lsp-item"
+  (setdyn :eval-env (table/proto-flatten (make-env root-env)))
+
+  (def bind-fiber (fiber/new |(do (defglobal "anil" nil)
+                                  (defglobal "hello" 'world)
+                                  (defglobal "atuple" [:a 1])
+                                  true) :e (dyn :eval-env)))
+  (def bf-return (resume bind-fiber))
+
+  (def test-cases @[['hello :symbol] [true :boolean] [% :function]
+                    [abstract? :cfunction] ["Hello world" :string]
+                    [@"Hello world" :buffer] [123 :number]
+                    [:keyword :keyword] [stderr :core/file]
+                    [(peg/compile 1) :core/peg] [{:a 1} :struct]
+                    [@{:a 1} :table] ['atuple :tuple]
+                    [@[:a 1] :array] # [(coro) :fiber]
+                    ['anil :nil]])
+
+  (test (map (juxt 1 |(binding-to-lsp-item (first $))) test-cases)
+        @[[:symbol    {:kind 12 :label hello}]
+          [:boolean   {:kind 6  :label true}]
+          [:function  {:kind 3  :label @%}]
+          [:cfunction {:kind 3  :label @abstract?}]
+          [:string    {:kind 6  :label "Hello world"}]
+          [:buffer    {:kind 6  :label @"Hello world"}]
+          [:number    {:kind 6  :label 123}]
+          [:keyword   {:kind 6  :label :keyword}]
+          [:core/file {:kind 17 :label "<core/file 0x1>"}]
+          [:core/peg  {:kind 6  :label "<core/peg 0x2>"}]
+          [:struct    {:kind 6  :label {:a 1}}]
+          [:table     {:kind 6  :label @{:a 1}}]
+          [:tuple     {:kind 6  :label atuple}]
+          [:array     {:kind 6  :label @[:a 1]}]
+          [:nil       {:kind 12 :label anil}]]))
+
+(deftest "test find-all-module-files"
+  (test (find-all-module-files (os/cwd))
+    @["/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/main.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/rpc.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/logging.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/misc.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/lookup.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/doc.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/eval.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/libs/fmt.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/libs/jpm-defs.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/libs/jayson.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/test/test-main.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/test/test-format-file-after.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/test/test-format-file-before.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/build/janet-lsp.jimage"]))
+
+(deftest "test find-all-module-files"
+  (test (find-all-module-files (os/cwd) true)
+    @["/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/main.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/rpc.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/logging.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/misc.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/lookup.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/doc.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/src/eval.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/libs/fmt.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/libs/jpm-defs.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/libs/jayson.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/test/test-main.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/test/test-format-file-after.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/test/test-format-file-before.janet"
+      "/home/caleb/projects/vscode/vscode-janet-plus-plus/janet-lsp/build/janet-lsp.jimage"]))
+
+(deftest "test find-unique-paths"
+  (test (find-unique-paths (find-all-module-files (os/cwd)))
+        @["./src/:all:.janet"
+          "./libs/:all:.janet"
+          "./test/:all:.janet"
+          "./build/:all:.jimage"]))
+
+(deftest "test find-unique-paths"
+  (test (find-unique-paths (find-all-module-files (os/cwd) true))
+        @["./src/:all:.janet"
+          "./libs/:all:.janet"
+          "./test/:all:.janet"
+          "./build/:all:.jimage"]))


### PR DESCRIPTION
- Bug fixes
  - Glitch when `textDocument/signatureHelp` is triggered on an empty line (i.e., when a signature hint is active and a carriage return is received)
- Misc
  - Added `--version`/`-v` flag to CLI interface
  - Added `--debug`/`-d` flag to CLI interface
  - Updated tests and test structure
  - Various minor refactors and cleanups