### PR TITLE
Fixes line encoding for strict clients (neovim)

### DIFF
--- a/src/main.janet
+++ b/src/main.janet
@@ -213,19 +213,15 @@
       "exit" (on-exit state params)
       [:noresponse state])))
 
-(defn line-ending []
-  (case (os/which)
-    :windows "\r\n\r\n"
-    "\n\n"))
-
-(defn read-offset []
+(def line-ending "\r\n\r\n")
+(def read-offset
   (case (os/which)
     :windows 1
     2))
 
 (defn write-response [file response]
   # Write headers
-  (file/write file (string "Content-Length: " (length response) (line-ending)))
+  (file/write file (string "Content-Length: " (length response) line-ending))
 
   # Write response
   (file/write file response)

--- a/src/main.janet
+++ b/src/main.janet
@@ -231,7 +231,7 @@
 
 (defn read-message []
   (let [input (file/read stdin :line)
-        content-length (+ (parse-content-length input) (read-offset))
+        content-length (+ (parse-content-length input) read-offset)
         input (file/read stdin content-length)]
     (json/decode input))) 
 

--- a/test/test-integration.janet
+++ b/test/test-integration.janet
@@ -2,14 +2,11 @@
 
 (use judge)
 
-(defn line-ending []
-  (case (os/which)
-    :windows "\r\n\r\n"
-    "\n\n"))
+(def line-ending "\r\n\r\n")
 
 (defn write-output [handle response]
   # Write headers
-  (:write handle (string "Content-Length: " (length response) (line-ending)))
+  (:write handle (string "Content-Length: " (length response) line-ending))
 
   # Write response
   (:write handle (string response (if (string/has-suffix? "\n" response) "" "\n")))


### PR DESCRIPTION
The line ending is *always* \r\n as far as neovim is concerned. Futher, these values are effectively constants, no reason to wrap them in function calls.

Without this change, neovim will ignore responses and behave very strangely.

I also intend to submit a PR to [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) to do some basic setup.