### PR TITLE
Bugfix: Typo, ":documnts" rather than ":documents" (missing the "e")

### DIFF
--- a/src/main.janet
+++ b/src/main.janet
@@ -97,7 +97,7 @@
             message {:method "textDocument/publishDiagnostics"
                      :params {:uri uri
                               :diagnostics diagnostics}}]
-        (put-in state [:documnts uri :eval-env] env)
+        (put-in state [:documents uri :eval-env] env)
         (logging/message message [:diagnostics])
         [:ok state message :notify true])
       [:noresponse state])))
@@ -145,7 +145,7 @@
       (let [message {:method "textDocument/publishDiagnostics"
                      :params {:uri uri
                               :diagnostics diagnostics}}]
-        (put-in state [:documnts uri :eval-env] env)
+        (put-in state [:documents uri :eval-env] env)
         (logging/message message [:diagnostics])
         [:ok state message :notify true])
       [:noresponse state])))


### PR DESCRIPTION
- Would have resulted in autocomplete suggestions failing to update as expected when diagnostics are push rather than pull (probably accounted for by diagnostics running elsewhere, but still wrong)