### PR TITLE
v0.0.9

### DIFF
--- a/src/main.janet
+++ b/src/main.janet
@@ -345,6 +345,13 @@
     "verbose" nil)
   [:noresponse state])
 
+(defn on-janet-tell-joke [state params]
+  # (eprint "What's brown and sticky? A stick!")
+  (let [message {:question "What's brown and sticky?"
+                 :answer "A stick!"}] 
+    (logging/message message [:joke])
+    [:ok state message]))
+
 (defn handle-message [message state]
   (let [id (get message "id")
         method (get message "method")
@@ -365,6 +372,7 @@
       # "textDocument/documentSymbol" (on-document-symbols state params) TODO: Implement this? See src/lsp/api.ts:121
       "textDocument/definition" (on-document-definition state params)
       "janet/serverInfo" (on-janet-serverinfo state params)
+      "janet/tellJoke" (on-janet-tell-joke state params)
       "shutdown" (on-shutdown state params)
       "exit" (on-exit state params)
       "$/setTrace" (on-set-trace state params)

--- a/src/main.janet
+++ b/src/main.janet
@@ -13,7 +13,7 @@
 
 (use judge)
 
-(def version "0.0.7")
+(def version "0.0.9")
 (def commit
   (with [proc (os/spawn ["git" "rev-parse" "--short" "HEAD"] :xp {:out :pipe})]
     (let [[out] (ev/gather

--- a/src/main.janet
+++ b/src/main.janet
@@ -77,9 +77,6 @@
                       :semi :equals :question :at :lbracket
                       :rbracket '1)))})
 
-(test (peg/match uri-percent-encoding-peg "file:///c%3A/Users/pete/Desktop/code/libmpsse")
-      @["file:///c:/Users/pete/Desktop/code/libmpsse"])
-
 (defn on-document-change
   ``
   Handler for the ["textDocument/didChange"](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didChange) event.

--- a/test/test-main.janet
+++ b/test/test-main.janet
@@ -7,6 +7,9 @@
   (test (main/parse-content-length "123:456:789") 456)
   (test (main/parse-content-length "0123:456::::789") 456))
 
+(test (peg/match uri-percent-encoding-peg "file:///c%3A/Users/pete/Desktop/code/libmpsse")
+      @["file:///c:/Users/pete/Desktop/code/libmpsse"])
+
 (deftest "test binding-to-lsp-item"
   (def eval-env (table/proto-flatten (make-env root-env)))
 


### PR DESCRIPTION
- Bug fix
  - Don't exit loop when `handle-message` returns an `:error` result, instead report it and reenter loop gracefully
- Misc
  - Bump version  
  - Formatting tweaks
  - New "janet/tellJoke" method (testing for future custom LSP RPC calls)
  - Move test from `src/main.janet` to `test/test-main.janet`