### PR TITLE
fix jimage invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Starting in version 0.0.3, you can start a debug console by passing `--console` 
 ```console
 $ ./build/janet-lsp --console
   OR
-$ janet ./build/janet-lsp.jimage --console
+$ janet -i ./build/janet-lsp.jimage --console
   OR
 $ janet ./src/main.janet --console
 ```


### PR DESCRIPTION
replace `janet janet-lsp.jimage` with `janet -i janet-lsp.jimage`, otherwise it tries to execute the file as janet source and fails with
```
build/janet-lsp.jimage:1:4: parse error: invalid utf-8 in symbol
```