### PR TITLE
v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 All notable changes to this project will be documented in this file.
 Format for entires is <version-string> - release date.
 
+## 0.0.10 - 2024-12-22
+
+- Logging 
+  - Rotate log files and overwrite eventually to avoid indefinite log file size
+  - Adjusted some log levels
+- New methods
+  - `enableDebug` and `disableDebug` - Allow clients to set `(dyn :debug)` while running
+  - `setLogLevel` and `setLogToFileLevel` - Allow clients to change debug level to console and file
+
+## 0.0.9 - 2024-12-07
+
+- Bugfixes
+  - Decode percent encoding in URIs before saving to or lookup from `state`
+  - Typo: ":documnts" rather than ":documents", causing redundant keys in `state` when diagnostics are pull (vs push)
+  - Don't exit loop when handle-message returns an `:error` result, instead report it and reenter loop gracefully
+- Misc
+  - Formatting tweaks
+  - New "janet/tellJoke" method (testing for future custom LSP RPC calls)
+
+## 0.0.8 - 2024-11-24
+
+- Bug Fixes
+  - Additional jpm defs (by @strangepete)
+  - New `eval-env`s should set `*out*` to `stderr`
+
 ## 0.0.7 - 2024-08-11
 
 - Core loop

--- a/project.janet
+++ b/project.janet
@@ -1,7 +1,7 @@
 (declare-project
   :name "janet-lsp"
   :description "A Language Server (LSP) for the Janet Programming Language"
-  :version "0.0.6"
+  :version "0.0.10"
   :dependencies ["https://github.com/janet-lang/spork.git"
                  "https://github.com/CFiggers/jayson.git"
                  "https://github.com/ianthehenry/judge.git"

--- a/src/doc.janet
+++ b/src/doc.janet
@@ -126,8 +126,8 @@
   "Get the documentation for a symbol in a given environment."
   [sym env]
   (assert env "my-doc*: env is nil")
-  (logging/info (string/format "env is: %m" env) [:hover] 1)
-  (logging/info (string/format "my-doc* tried: %m" (env sym)) [:hover] 1)
+  (logging/info (string/format "env is: %m" env) [:hover] 3)
+  (logging/info (string/format "my-doc* tried: %m" (env sym)) [:hover] 3)
   (if-let [x (env sym)]
     (make-module-entry x)
     (if (has-value? '[break def do fn if quasiquote quote

--- a/src/eval.janet
+++ b/src/eval.janet
@@ -54,7 +54,7 @@
 
 (defn eval-buffer [str &opt filename]
   (logging/info (string/format "`eval-buffer` received filename: `%s`" (or filename "none")) [:evaluation] 1)
-  (logging/info (string/format "`eval-buffer` received str: `%s`" str) [:evaluation] 2)
+  (logging/info (string/format "`eval-buffer` received str: `%s`" str) [:evaluation] 3)
 
   (default filename "eval.janet")
   (var state (string str))
@@ -92,7 +92,7 @@
                                        :location [0 0]})))
           returnval) :e fresh-env))
   (def eval-fiber-return (resume eval-fiber))
-  (logging/info (string/format "`eval-buffer` is returning: %m" eval-fiber-return) [:evaluation] 2)
+  (logging/info (string/format "`eval-buffer` is returning: %m" eval-fiber-return) [:evaluation] 3)
   [eval-fiber-return fresh-env])
 
 # tests

--- a/src/logging.janet
+++ b/src/logging.janet
@@ -3,7 +3,6 @@
 (import spork/rpc)
 
 (defn log [output categories &opt level]
-
   (unless (dyn :debug) (break))
 
   (unless (dyn :client)
@@ -18,37 +17,43 @@
     (print (:print (dyn :client) output)))
 
   (when (dyn :debug)
-    # Always log to file
-    (try
-      (do
-        (def logfiles (filter |(string/has-prefix? "janetlsp.log" $) (os/dir ".")))
-        (when (> (get (os/stat "janetlsp.log") :size) 5000000)
-          (when (and (has-value? logfiles "janetlsp.log")
-                     (has-value? logfiles "janetlsp.log.1"))
-            (when (and (has-value? logfiles "janetlsp.log.1")
-                       (has-value? logfiles "janetlsp.log.2"))
-              (when (and (has-value? logfiles "janetlsp.log.2")
-                         (has-value? logfiles "janetlsp.log.3"))
-                (when (and (has-value? logfiles "janetlsp.log.3")
-                           (has-value? logfiles "janetlsp.log.4"))
-                  (when (and (has-value? logfiles "janetlsp.log.4")
-                             (has-value? logfiles "janetlsp.log.5"))
-                    (os/rm "janetlsp.log.5"))
-                  (os/rename "janetlsp.log.4" "janetlsp.log.5"))
-                (os/rename "janetlsp.log.3" "janetlsp.log.4"))
-              (os/rename "janetlsp.log.2" "janetlsp.log.3"))
-            (os/rename "janetlsp.log.1" "janetlsp.log"))
-          (os/rename "janetlsp.log" "janetlsp.log.1"))
-        (spit "janetlsp.log" (string output "\n") :a))
-      ([_]))
+    
+    # Ensure log file exists
+    (unless (os/stat "janetlsp.log")
+      (spit "janetlsp.log" ""))
+
+    # Log to file, all categories but only if this log's level is <= the specified level
+    (when (or (nil? level) # There is no level specified on this log
+              (<= level (dyn :log-to-file-level)))
+      (try
+        (do
+          (def logfiles (filter |(string/has-prefix? "janetlsp.log" $) (os/dir ".")))
+          (when (> (get (os/stat "janetlsp.log") :size) 5000000)
+            (when (and (has-value? logfiles "janetlsp.log") (has-value? logfiles "janetlsp.log.1"))
+              (when (and (has-value? logfiles "janetlsp.log.1") (has-value? logfiles "janetlsp.log.2"))
+                (when (and (has-value? logfiles "janetlsp.log.2") (has-value? logfiles "janetlsp.log.3"))
+                  (when (and (has-value? logfiles "janetlsp.log.3") (has-value? logfiles "janetlsp.log.4"))
+                    (when (and (has-value? logfiles "janetlsp.log.4") (has-value? logfiles "janetlsp.log.5"))
+                      (os/rm "janetlsp.log.5"))
+                    (os/rename "janetlsp.log.4" "janetlsp.log.5"))
+                  (os/rename "janetlsp.log.3" "janetlsp.log.4"))
+                (os/rename "janetlsp.log.2" "janetlsp.log.3"))
+              (os/rename "janetlsp.log.1" "janetlsp.log.2"))
+            (os/rename "janetlsp.log" "janetlsp.log.1")
+            (spit "janetlsp.log" ""))
+          (spit "janetlsp.log" (string output "\n") :a))
+        ([e]
+         (file/write stderr (string/format "error while trying to write to log file: %q\n" e)))))
+
+    # Log to console, only specified categories and if this log's level is >= the specified level
     (when (and
             # Category Match
-            (or (empty? (dyn :log-categories)) # No log categories are specified
-                (empty? categories) # OR, this log doesn't specify a categories (default to sending it)
-                (any? (map |(has-value? (dyn :log-categories) $) categories))) # Any of this log's categories is in the target categories
+           (or (empty? (dyn :log-categories)) # No log categories are specified
+               (empty? categories) # OR, this log doesn't specify a categories (default to sending it)
+               (any? (map |(has-value? (dyn :log-categories) $) categories))) # Any of this log's categories is in the target categories
             # Level Match
-            (or (nil? level) # There is no level specified on this log
-                (<= level (dyn :log-level)))) # OR, this log's level is <= the specified level
+           (or (nil? level) # There is no level specified on this log
+               (<= level (dyn :log-level)))) # OR, this log's level is <= the specified level
 
       (comment (eprintf "Debug is: %m" (dyn :debug))
 

--- a/src/logging.janet
+++ b/src/logging.janet
@@ -19,16 +19,36 @@
 
   (when (dyn :debug)
     # Always log to file
-    (try (spit "janetlsp.log.txt" (string output "\n") :a)
-         ([_]))
+    (try
+      (do
+        (def logfiles (filter |(string/has-prefix? "janetlsp.log" $) (os/dir ".")))
+        (when (> (get (os/stat "janetlsp.log") :size) 5000000)
+          (when (and (has-value? logfiles "janetlsp.log")
+                     (has-value? logfiles "janetlsp.log.1"))
+            (when (and (has-value? logfiles "janetlsp.log.1")
+                       (has-value? logfiles "janetlsp.log.2"))
+              (when (and (has-value? logfiles "janetlsp.log.2")
+                         (has-value? logfiles "janetlsp.log.3"))
+                (when (and (has-value? logfiles "janetlsp.log.3")
+                           (has-value? logfiles "janetlsp.log.4"))
+                  (when (and (has-value? logfiles "janetlsp.log.4")
+                             (has-value? logfiles "janetlsp.log.5"))
+                    (os/rm "janetlsp.log.5"))
+                  (os/rename "janetlsp.log.4" "janetlsp.log.5"))
+                (os/rename "janetlsp.log.3" "janetlsp.log.4"))
+              (os/rename "janetlsp.log.2" "janetlsp.log.3"))
+            (os/rename "janetlsp.log.1" "janetlsp.log"))
+          (os/rename "janetlsp.log" "janetlsp.log.1"))
+        (spit "janetlsp.log" (string output "\n") :a))
+      ([_]))
     (when (and
-           # Category Match
-           (or (empty? (dyn :log-categories)) # No log categories are specified
-               (empty? categories) # OR, this log doesn't specify a categories (default to sending it)
-               (any? (map |(has-value? (dyn :log-categories) $) categories))) # Any of this log's categories is in the target categories
-           # Level Match
-           (or (nil? level) # There is no level specified on this log
-               (<= level (dyn :log-level)))) # OR, this log's level is <= the specified level
+            # Category Match
+            (or (empty? (dyn :log-categories)) # No log categories are specified
+                (empty? categories) # OR, this log doesn't specify a categories (default to sending it)
+                (any? (map |(has-value? (dyn :log-categories) $) categories))) # Any of this log's categories is in the target categories
+            # Level Match
+            (or (nil? level) # There is no level specified on this log
+                (<= level (dyn :log-level)))) # OR, this log's level is <= the specified level
 
       (comment (eprintf "Debug is: %m" (dyn :debug))
 
@@ -40,7 +60,6 @@
                             (nil? categories)
                             (has-value? (dyn :log-categories) categories)))
 
-
                (eprintf "is level nil? %m" (nil? level))
                (eprintf "is level high enough? %m" (<= level (dyn :log-level)))
                (eprintf "second condition %m" (or (nil? level)
@@ -51,12 +70,12 @@
 
 (defmacro info [output categories &opt level id]
   (with-syms [$output $categories $level $id]
-    ~(let [,$output (case (type ,output) :string ,output (string/format "%m" ,output)) 
-           ,$categories ,categories 
-           ,$level ,level 
-           ,$id ,id] 
-       (,log (string/format "[INFO%s:%s] %s" (if ,$id (string ":" ,$id) "") (first ,$categories) ,$output) 
-            ,$categories ,$level))))
+    ~(let [,$output (case (type ,output) :string ,output (string/format "%m" ,output))
+           ,$categories ,categories
+           ,$level ,level
+           ,$id ,id]
+       (,log (string/format "[INFO%s:%s] %s" (if ,$id (string ":" ,$id) "") (first ,$categories) ,$output)
+             ,$categories ,$level))))
 
 (defmacro message [output categories &opt level id]
   (with-syms [$output $categories $level $id]
@@ -65,7 +84,7 @@
            ,$level ,level
            ,$id ,id]
        (,log (string/format "[MESSAGE%s:%s] %s" (if ,$id (string ":" ,$id) "") (first ,$categories) ,$output)
-            ,$categories ,$level))))
+             ,$categories ,$level))))
 
 (defmacro err [output categories &opt level id]
   (with-syms [$output $categories $level $id]

--- a/src/main.janet
+++ b/src/main.janet
@@ -13,7 +13,7 @@
 
 (use judge)
 
-(def version "0.0.9")
+(def version "0.0.10")
 (def commit
   (with [proc (os/spawn ["git" "rev-parse" "--short" "HEAD"] :xp {:out :pipe})]
     (let [[out] (ev/gather

--- a/src/main.janet
+++ b/src/main.janet
@@ -38,7 +38,7 @@
                             (if (string/has-prefix? "file:" uri)
                               (string/slice uri 5) uri)))]
 
-    (logging/info (string/format "`eval-buffer` returned: %m" diagnostics) [:evaluation])
+    (logging/info (string/format "`eval-buffer` returned: %m" diagnostics) [:evaluation] 3)
 
     (each res diagnostics
       (match res
@@ -49,8 +49,8 @@
                       :end {:line (max 0 (dec line)) :character col}}
                      :message message})))
 
-    (logging/info (string/format "`run-diagnostics` is returning these errors: %m" items) [:evaluation])
-    (logging/info (string/format "`run-diagnostics` is returning this eval-context: %m" env) [:evaluation] 1)
+    (logging/info (string/format "`run-diagnostics` is returning these errors: %m" items) [:evaluation] 2)
+    (logging/info (string/format "`run-diagnostics` is returning this eval-context: %m" env) [:evaluation] 3)
     [items env]))
 
 (def uri-percent-encoding-peg
@@ -154,7 +154,7 @@
     ~(let [,$name ,name
            ,$eval-env ,eval-env
            s (get-in ,$eval-env [,$name :value] ,$name)]
-       (,logging/log (string/format "binding-to-lsp-item: s is %m" s) [:completion] 2)
+       (,logging/log (string/format "binding-to-lsp-item: s is %m" s) [:completion] 3)
        {:label ,$name :kind
         (case (type s)
           :symbol    12 :boolean   6


### PR DESCRIPTION
- Logging 
  - Rotate log files and overwrite eventually to avoid indefinite log file size
  - Adjusted some log levels
- New methods
  - `enableDebug` and `disableDebug` - Allow clients to set `(dyn :debug)` while running
  - `setLogLevel` and `setLogToFileLevel` - Allow clients to change debug level to console and file