### PR TITLE
Check for additional word terminals in word-at

### DIFF
--- a/src/lookup.janet
+++ b/src/lookup.janet
@@ -13,9 +13,9 @@
              ,|[$0 $1 (dec $2)])
       :word (/ (* (position)
                   (<- (some (if-not (set " ()[]{}`'\"") 1)))
-                  (? (+ :s ")"))
-                  (position))
-               ,|[$0 $1 (dec $2)])
+                  (position)
+                  (? (+ :s (set ")}]\""))))
+               ,|[$0 $1 $2])
       :main (some (+ :paren :ws :word -1))}))
 
 (defmacro first-where [pred ds]

--- a/test/test-lookup.janet
+++ b/test/test-lookup.janet
@@ -47,8 +47,7 @@
         [6 "main" 10]
         [11 "" 11]
         [12 "&" 13]
-        [14 "args" 17]
-        [18 "" 18]
+        [14 "args" 18]
         [19 "" 19]
         [20 "" 20]
         [21 "+" 22]
@@ -58,7 +57,7 @@
 
 (test (peg/match word-peg "") nil)
 
-(test (word-at {:line 0 :character 16} "(def- parse-peg\n") {:range [6 14] :word "parse-peg"})
+(test (word-at {:line 0 :character 16} "(def- parse-peg\n") {:range [6 15] :word "parse-peg"})
 
 (test (word-at {:line 1 :character 0} "(import )\n") {:range [0 0] :word ""})
 
@@ -308,29 +307,37 @@
         @[[0 "word" 4]
           [5 "not" 8]
           [9 "a" 10]
-          [11 "word" 14]]))
+          [11 "word" 15]]))
 
 (deftest "test word-at1"
-  (test (map |(word-at {:line 0 :character $} "word not a word") (range 15)) @[{:range [0 4] :word "word"} {:range [0 4] :word "word"} {:range [0 4] :word "word"} {:range [0 4] :word "word"} {:range [0 4] :word "word"} {:range [5 8] :word "not"} {:range [5 8] :word "not"} {:range [5 8] :word "not"} {:range [5 8] :word "not"} {:range [9 10] :word "a"} {:range [9 10] :word "a"} {:range [11 14] :word "word"} {:range [11 14] :word "word"} {:range [11 14] :word "word"} {:range [11 14] :word "word"}]))
+  (test (map |(word-at {:line 0 :character $} "word not a word") (range 15)) @[{:range [0 4] :word "word"} {:range [0 4] :word "word"} {:range [0 4] :word "word"} {:range [0 4] :word "word"} {:range [0 4] :word "word"} {:range [5 8] :word "not"} {:range [5 8] :word "not"} {:range [5 8] :word "not"} {:range [5 8] :word "not"} {:range [9 10] :word "a"} {:range [9 10] :word "a"} {:range [11 15] :word "word"} {:range [11 15] :word "word"} {:range [11 15] :word "word"} {:range [11 15] :word "word"}]))
 
 (deftest "test word-peg2"
   (def sample "(defn main [& args] (print \"hello world\"))")
-  (test (peg/match word-peg sample) @[[0 "" 0] [1 "defn" 5] [6 "main" 10] [11 "" 11] [12 "&" 13] [14 "args" 17] [18 "" 18] [19 "" 19] [20 "" 20] [21 "print" 26] [27 "" 27] [28 "hello" 33] [34 "world" 38] [39 "" 39] [40 "" 40] [41 "" 41]]))
+  (test (peg/match word-peg sample) @[[0 "" 0] [1 "defn" 5] [6 "main" 10] [11 "" 11] [12 "&" 13] [14 "args" 18] [19 "" 19] [20 "" 20] [21 "print" 26] [27 "" 27] [28 "hello" 33] [34 "world" 39] [40 "" 40] [41 "" 41]]))
 
 (deftest "test word-peg3"
-  (test (map |(word-at {:line 0 :character $} "(defn main [& args] (print \"hello world\"))") (range 42)) @[{:range [0 0] :word ""} {:range [1 5] :word "defn"} {:range [1 5] :word "defn"} {:range [1 5] :word "defn"} {:range [1 5] :word "defn"} {:range [1 5] :word "defn"} {:range [6 10] :word "main"} {:range [6 10] :word "main"} {:range [6 10] :word "main"} {:range [6 10] :word "main"} {:range [6 10] :word "main"} {:range [11 11] :word ""} {:range [12 13] :word "&"} {:range [12 13] :word "&"} {:range [14 17] :word "args"} {:range [14 17] :word "args"} {:range [14 17] :word "args"} {:range [14 17] :word "args"} {:range [18 18] :word ""} {:range [19 19] :word ""} {:range [20 20] :word ""} {:range [21 26] :word "print"} {:range [21 26] :word "print"} {:range [21 26] :word "print"} {:range [21 26] :word "print"} {:range [21 26] :word "print"} {:range [21 26] :word "print"} {:range [27 27] :word ""} {:range [28 33] :word "hello"} {:range [28 33] :word "hello"} {:range [28 33] :word "hello"} {:range [28 33] :word "hello"} {:range [28 33] :word "hello"} {:range [28 33] :word "hello"} {:range [34 38] :word "world"} {:range [34 38] :word "world"} {:range [34 38] :word "world"} {:range [34 38] :word "world"} {:range [34 38] :word "world"} {:range [39 39] :word ""} {:range [40 40] :word ""} {:range [41 41] :word ""}]))
+  (test (map |(word-at {:line 0 :character $} "(defn main [& args] (print \"hello world\"))") (range 42)) @[{:range [0 0] :word ""} {:range [1 5] :word "defn"} {:range [1 5] :word "defn"} {:range [1 5] :word "defn"} {:range [1 5] :word "defn"} {:range [1 5] :word "defn"} {:range [6 10] :word "main"} {:range [6 10] :word "main"} {:range [6 10] :word "main"} {:range [6 10] :word "main"} {:range [6 10] :word "main"} {:range [11 11] :word ""} {:range [12 13] :word "&"} {:range [12 13] :word "&"} {:range [14 18] :word "args"} {:range [14 18] :word "args"} {:range [14 18] :word "args"} {:range [14 18] :word "args"} {:range [14 18] :word "args"} {:range [19 19] :word ""} {:range [20 20] :word ""} {:range [21 26] :word "print"} {:range [21 26] :word "print"} {:range [21 26] :word "print"} {:range [21 26] :word "print"} {:range [21 26] :word "print"} {:range [21 26] :word "print"} {:range [27 27] :word ""} {:range [28 33] :word "hello"} {:range [28 33] :word "hello"} {:range [28 33] :word "hello"} {:range [28 33] :word "hello"} {:range [28 33] :word "hello"} {:range [28 33] :word "hello"} {:range [34 39] :word "world"} {:range [34 39] :word "world"} {:range [34 39] :word "world"} {:range [34 39] :word "world"} {:range [34 39] :word "world"} {:range [34 39] :word "world"} {:range [40 40] :word ""} {:range [41 41] :word ""}]))
 
 (deftest "word-at-peg: line 0, character 12, of \"word not a word\n23\n45\""
-  (test (word-at {:line 0 :character 12} "word not a word\n23\n45") {:range [11 14] :word "word"}))
+  (test (word-at {:line 0 :character 12} "word not a word\n23\n45") {:range [11 15] :word "word"}))
 
 (deftest "word-at-peg: line 1, character 6, of \"\nword not a word\n23\n45\""
   (test (word-at {:line 1 :character 6} "\nword not a word\n23\n45") {:range [5 8] :word "not"}))
 
 (deftest "word-at-peg: line 0, character 0, of \"word\""
-  (test (word-at {:line 0 :character 0} "word") {:range [0 3] :word "word"}))
+  (test (word-at {:line 0 :character 0} "word") {:range [0 4] :word "word"}))
 
 (deftest "word-at-peg: line 0, character 4, of \" word \""
   (test (word-at {:line 0 :character 4} " word ") {:range [1 5] :word "word"}))
 
 (deftest "word-at-peg: line 0, character 0, of \"  \""
   (test (word-at {:line 0 :character 0} "  ") {:range [0 1] :word ""}))
+
+(deftest "end of word boundaries"
+  (test (word-at {:line 0 :character 0} "hello") {:range [0 5] :word "hello"})
+  (test (word-at {:line 0 :character 1} "(hello)") {:range [1 6] :word "hello"})
+  (test (word-at {:line 0 :character 1} "[hello]") {:range [1 6] :word "hello"})
+  (test (word-at {:line 0 :character 1} "{hello}") {:range [1 6] :word "hello"})
+  (test (word-at {:line 0 :character 1} "\"hello\"") {:range [1 6] :word "hello"}))
+


### PR DESCRIPTION
The prior implementation of `word-at` would miss the final character in some cases where the word is near a boundary such as the end of line or terminating punctuation.

This PR handles those cases as well as adds in explicit unit testing for those cases.