### PR TITLE
completion: add completion provider trigger characters

### DIFF
--- a/src/main.janet
+++ b/src/main.janet
@@ -254,10 +254,10 @@
     (setdyn :push-diagnostics false)
     (setdyn :push-diagnostics true))
 
-  (let [message {:capabilities {:completionProvider {:resolveProvider true}
+  (let [message {:capabilities {:completionProvider {:resolveProvider true
+                                                     :triggerCharacters ["/"]}
                                 :textDocumentSync {:openClose true
-                                                   :change 1 # send the Full document https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentSyncKind
-}
+                                                   :change 1} # send the Full document https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentSyncKind
                                 :diagnosticProvider {:interFileDependencies true
                                                      :workspaceDiagnostics false}
                                 :hoverProvider true


### PR DESCRIPTION
Currently when sending server capabilities, implementation is missing trigger characters list for the completion provider.
This allows completion engines to not treat things like slash as word boundaries and allow completing correctly module paths in import expressions and functions prefixed with module names.

This is what [clojure-lsp](https://github.com/clojure-lsp/clojure-lsp/blob/df9ef39b3ef86718c118b67bb7af48f3bec357d2/cli/src/clojure_lsp/server.clj#L523) does and what [blink.cmp](https://github.com/saghen/blink.cmp/blob/8ca29c2eb34f5ce4770bffc0d62e6f636a4e8526/lua/blink/cmp/sources/lsp/init.lua#L37) neovim completion engine expects.